### PR TITLE
In-game documents go missing after server restart

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -343,3 +343,12 @@ function dump(o)
       return tostring(o)
    end
 end
+
+RegisterNetEvent('esx:playerLoaded')
+AddEventHandler('esx:playerLoaded', function(playerData)
+    if playerData then
+        GetAllUserForms()
+    end
+    GetAllUserForms()
+
+end)


### PR DESCRIPTION
This should fix the issue of players having their documents missing once they relog to the server.